### PR TITLE
Fix for user-secrets file missing in /etc/required-secrets/

### DIFF
--- a/recipes-akraino/openstack-ansible/openstack-ansible_git.bb
+++ b/recipes-akraino/openstack-ansible/openstack-ansible_git.bb
@@ -50,7 +50,8 @@ RDEPENDS_${PN} += " \
         python-virtualenv \
         "
 
-FILES_${PN} += "/opt/openstack-ansible/* /usr/local/bin/*" 
+FILES_${PN} += "/opt/openstack-ansible/* /usr/local/bin/* /etc/required-secrets/*" 
+
 do_install_append() {
 
         install -d  ${D}/opt/openstack-ansible
@@ -69,6 +70,8 @@ do_install_append() {
         mkdir -p ${D}${provisioning_path}
         mkdir -p ${D}${postconfig_path}
 
+        mkdir -p ${D}${sysconfdir}/required-secrets
+	cp -f ${S}/etc/openstack_deploy/user_secrets.yml ${D}${sysconfdir}/required-secrets/000-user_secrets.yml
 }
 
 pkg_postinst_ontarget_${PN}() {
@@ -89,8 +92,4 @@ pkg_postinst_ontarget_${PN}() {
         ln -s /opt/openstack-ansible/playbooks/hosts_config.yml ${postconfig_path}
         ln -s /opt/openstack-ansible/playbooks/os-ironic-install.yml ${postconfig_path}
         ln -s /opt/openstack-ansible/playbooks/os-keystone-install.yml ${postconfig_path}
-        
-        mkdir -p ${sysconfdir}/required-secrets
-        cp -f /opt/openstack-ansible/etc/openstack_deploy/user_secrets.yml ${sysconfdir}/required-secrets/000-user_secrets.yml
-
 }

--- a/recipes-core/packagegroups/packagegroup-akraino.bb
+++ b/recipes-core/packagegroups/packagegroup-akraino.bb
@@ -94,6 +94,7 @@ RDEPENDS_${PN}-base = "\
     uwsgi \
     xfsprogs \
     xfsprogs-mkfs \
+    yarf \
 "
 
 RDEPENDS_${PN}-docker = "\


### PR DESCRIPTION
  openstack-ansible:
    /etc/openstack_deploy/user_secrets.yml cannot be copied during pkg_postinst_ontarget
  yarf:
    this split pkg missing in the rootfs

fix #51
